### PR TITLE
Fixed an issue where the frame rate couldn't print after time revision.

### DIFF
--- a/src/com/base/engine/core/CoreEngine.java
+++ b/src/com/base/engine/core/CoreEngine.java
@@ -66,7 +66,7 @@ public class CoreEngine
 		isRunning = true;
 		
 		int frames = 0;
-		long frameCounter = 0;
+		double frameCounter = 0;
 
 		game.init();
 


### PR DESCRIPTION
I found that after Video #37 with the time being revised to operate in seconds, the frame rate would no longer print correctly. Debugging showed that the frameCounter always rounded down to 0 after the change, since it was declared as long intead of double!
