### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,20 +5,20 @@ thebennybox 3D Game Engine
 
 Tutorial found here: https://www.youtube.com/playlist?list=PLEETnX-uPtBXP_B2yupUKlflXBznWIlL5
 
-##Build Dependencies##
+## Build Dependencies ##
 - [JAVA](https://www.java.com/en/download/)
 - BUILD TOOLCHAIN (Can be any one of the following, doesn't need to be all of them)
 	- [Eclipse](http://eclipse.org/)
 	- [NetBeans](https://netbeans.org/)
 	- [IntelliJ IDEA](http://www.jetbrains.com/idea/)
 
-##Simple Build Instructions##
-###Using IDE###
+## Simple Build Instructions ##
+### Using IDE ###
 - Open your preferred Java IDE, and create a new project.
 - Import everything under the src folder as source files.
 - Copy the res folder into your Java IDE's folder for your project.
 - Build and run
 
-##Additional Credits##
+## Additional Credits ##
 - Etay Meiri, for http://ogldev.atspace.co.uk/ which inspired the base code for this repository.
 - Everyone who's created or contributed to issues and pull requests, which make the project better!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
